### PR TITLE
Address a number of nits in this module.

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -16,3 +16,5 @@ jobs:
           output-file: README.md
           output-method: inject
           fail-on-diff: "true"
+      - if: failure()
+        run: cat README.md

--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_cloud_run_v2_job.job](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_job) | resource |
+| [google_cloud_run_v2_job_iam_binding.authorize-calls](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_job_iam_binding) | resource |
 | [google_cloud_scheduler_job.cron](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_scheduler_job) | resource |
-| [google_project_iam_member.cron_run_invoker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.cron_secretmanager_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.cloud_run_api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_project_service.cloudscheduler](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_service_account.delivery](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [ko_build.image](https://registry.terraform.io/providers/ko-build/ko/latest/docs/resources/build) | resource |
 
 ## Inputs

--- a/example/example.tf
+++ b/example/example.tf
@@ -7,16 +7,17 @@ variable "project_id" {
   description = "The project that will host the cron job."
 }
 
-# NB: Prefer a Service Account with fewer permissions.
-data "google_compute_default_service_account" "default" {
+resource "google_service_account" "this" {
+  project    = var.project_id
+  account_id = "terraform-google-cron-example"
 }
 
 module "cron" {
   source = "../"
 
-  project_id            = var.project_id
-  name                  = "example"
-  service_account = data.google_compute_default_service_account.default.email
+  project_id      = var.project_id
+  name            = "example"
+  service_account = google_service_account.this.email
 
   importpath  = "github.com/chainguard-dev/terraform-google-cron/example"
   working_dir = path.module


### PR DESCRIPTION
1. Create a dedicated service account for delivery (least privilege).  Now the incoming token can only be used to invoke the job, and the job's tokens can't be used to spawn more jobs (unless granted externally).

2. Restrict the invoker grant from project-level (currently) to just the specific job.

3. Remove the `secretAccessor` grant, which previously granted project-wide secret access(!) instead of access to the specific secrets being projected as environment variables.